### PR TITLE
Add QML models dependency

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -32,7 +32,9 @@ Package: libignition-gazebo3
 Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         qml-module-qtqml-models2
 Multi-Arch: same
 Description: Ignition Gazebo classes and functions for robot apps - Shared library
   Ignition Gazebo is a component in the ignition framework, a set of libraries


### PR DESCRIPTION
When we removed the binary package in https://github.com/ignition-release/ign-gazebo3-release/commit/72e15da9cd9dee08667a60f270abdfc08dad28c4, we also removed the only package that installed the `qml` models dependency.

I think it makes sense to have that as a dependency of the `libignition-gazebo3` (as opposed to `-dev`) package since it's a runtime dependency.