### PR TITLE
add libsdformat9 dependency bump to libignition-gazebo3-dev

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -73,7 +73,7 @@ Depends: libtinyxml2-dev,
          libignition-sensors3-dev,
          libignition-rendering3-dev (>= 3.2.0),
          libignition-transport8-log-dev,
-         libsdformat9-dev (>= 9.2.0),
+         libsdformat9-dev (>= 9.3.0),
          libignition-gazebo3 (= ${binary:Version}),
          libignition-gazebo3-plugins (= ${binary:Version}),
          ${misc:Depends}


### PR DESCRIPTION
Updating `libsdformat9` to be at least version `9.3.0` for `libignition-gazebo3-dev`. This is to match the changes made in https://github.com/ignition-release/ign-gazebo3-release/pull/4/files.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>